### PR TITLE
feat(embed): exportPNG canvas compositor + postMessage export protocol

### DIFF
--- a/anyplotlib/FIGURE_ESM.md
+++ b/anyplotlib/FIGURE_ESM.md
@@ -309,3 +309,42 @@ Python → JS (set widget position from Python):
   widget.set(…) → Figure._push_widget → event_json with source:'python'
   → model.on('change:event_json') patches overlay_widgets + redraws
 ```
+
+---
+
+## PNG export (`exportPNG`)
+
+`render()` now RETURNS an internal API object `{ panels, exportPNG,
+_gpuDisposeImagePanel, _gpuDisposePanel }` (anywidget ignores render()'s return;
+`mount()` captures it — this also fixed a latent bug where the old
+mount-handle `dispose()` referenced `panels`/`_gpuDispose*` from module scope,
+which are inside `render`'s closure, and silently threw). The mount handle
+exposes `handle.exportPNG({scale=1, includeWidgets=false}) →
+Promise<{dataUrl,width,height}>`.
+
+`exportPNG(opts)` (inside `render`, near `redrawAll`) composites the WHOLE
+figure onto one offscreen canvas at `devicePixelRatio × scale`:
+
+- **WebGPU hazard first**: a WebGPU canvas's drawing buffer is only valid right
+  after its render pass, so exportPNG force-calls `draw2d(p)` on every
+  active-GPU 2-D panel (`p._gpu==='active' && p.gpuCanvas` visible) to re-submit
+  its pass, THEN composites in the SAME synchronous task — so
+  `drawImage(gpuCanvas,…)` reads live pixels, not a blank buffer.
+- **Extent**: `fig_width/height + 2×8 px` gridDiv padding (NOT the measured
+  `gridDiv` width — a bare `mount()` page has no `.apl-outer` inline-block CSS,
+  so the grid container can stretch to the viewport). **Origin**: `gridDiv`'s
+  top-left (grid tracks are fixed-px + left-anchored, so panels sit correctly).
+- **Per-panel z-order** (`_drawEl` positions each canvas by its
+  `getBoundingClientRect()` relative to the root): gpuCanvas (z0) → plotCanvas
+  (z1) → x/yAxisCanvas → cbCanvas → [overlayCanvas z5 only if `includeWidgets`]
+  → markersCanvas (z6) → scaleBar (z7) → titleCanvas (z8). Grid panels first,
+  then insets (`p.isInset`) on top. Status bars / stats overlays are excluded.
+- Ends with `out.toDataURL('image/png')`; rejects the promise with a message on
+  failure (no 2-D context, `toDataURL` throw).
+
+The standalone HTML template (`_repr_utils.build_standalone_html`) captures
+render()'s api into `_aplRenderApi` and adds a `message` listener:
+`{type:'anyplotlib_export_png', requestId, opts}` → `exportPNG(opts)` → replies
+`{type:'anyplotlib_export_png_result', requestId, dataUrl, width, height}` (or
+`{…, error}`) to `event.source` (targetOrigin `'*'`) — the same channel the
+`awi_state` postMessages ride. Tests: `tests/test_embed/test_export_png.py`.

--- a/anyplotlib/_repr_utils.py
+++ b/anyplotlib/_repr_utils.py
@@ -193,10 +193,14 @@ const blobUrl = URL.createObjectURL(blob);
 const el      = document.getElementById("widget-root");
 const model   = makeModel(STATE);
 
+// render() returns an internal API ({{ panels, exportPNG, ... }}) that the PNG
+// export protocol below needs.  Held here so the message listener can reach it.
+let _aplRenderApi = null;
+
 import(blobUrl).then(mod => {{
   const renderFn = mod.default?.render ?? mod.render;
   if (typeof renderFn === "function") {{
-    renderFn({{ model, el }});
+    _aplRenderApi = renderFn({{ model, el }});
   }} else {{
     el.textContent = "ESM has no render() export";
   }}
@@ -249,6 +253,40 @@ window.addEventListener('message', (e) => {{
     }} catch (_) {{}}
     _fromParent = false;
     return;
+  }}
+}});
+
+// ── PNG export protocol ──────────────────────────────────────────────────────
+// Rides the same postMessage channel as the state updates above.  A parent page
+// (or the SpyDE report harvester) requests a composite PNG of the whole figure:
+//   → {{ type: 'anyplotlib_export_png', requestId, opts }}
+// and receives back, on event.source (targetOrigin '*'):
+//   ← {{ type: 'anyplotlib_export_png_result', requestId, dataUrl, width, height }}
+//   ← {{ type: 'anyplotlib_export_png_result', requestId, error }}   (on failure)
+// `opts` is forwarded verbatim to handle.exportPNG ({{ scale?, includeWidgets? }}).
+window.addEventListener('message', (e) => {{
+  if (!e.data || e.data.type !== 'anyplotlib_export_png') return;
+  const requestId = e.data.requestId;
+  const source = e.source;
+  const reply = (msg) => {{
+    try {{
+      if (source && typeof source.postMessage === 'function') {{
+        source.postMessage(Object.assign(
+          {{ type: 'anyplotlib_export_png_result', requestId }}, msg), '*');
+      }}
+    }} catch (_) {{}}
+  }};
+  try {{
+    if (!_aplRenderApi || typeof _aplRenderApi.exportPNG !== 'function') {{
+      reply({{ error: 'figure not ready (exportPNG unavailable)' }});
+      return;
+    }}
+    Promise.resolve(_aplRenderApi.exportPNG(e.data.opts || {{}}))
+      .then((res) => reply({{
+        dataUrl: res.dataUrl, width: res.width, height: res.height }}))
+      .catch((err) => reply({{ error: String(err && err.message || err) }}));
+  }} catch (err) {{
+    reply({{ error: String(err && err.message || err) }});
   }}
 }});
 </script>

--- a/anyplotlib/figure_esm.js
+++ b/anyplotlib/figure_esm.js
@@ -6892,6 +6892,112 @@ fn fs(in : VsOut) -> @location(0) vec4<f32> {
     for(const p of panels.values()) _redrawPanel(p);
   }
 
+  // ── PNG export ────────────────────────────────────────────────────────────
+  // Composite the WHOLE figure (all panels, insets, background) onto one
+  // offscreen canvas and return a PNG data URL.  Used by handle.exportPNG()
+  // and the standalone-HTML postMessage export protocol.
+  //
+  //   opts.scale          extra multiplier on top of devicePixelRatio (1)
+  //   opts.includeWidgets include the interactive overlay canvas (false)
+  //
+  // The composite is positioned by each element's on-screen bounding box
+  // relative to the figure background (`gridDiv`), so multi-panel grids and
+  // corner insets export as one correctly-arranged image without re-deriving
+  // any layout math.  Elements are drawn in DOM/z-order per panel: gpuCanvas
+  // (beneath) → plotCanvas → [overlayCanvas] → markersCanvas → axis canvases →
+  // colorbar → scale bar → title.  Status bars and other hover chrome are
+  // excluded.
+  function exportPNG(opts) {
+    const o = opts || {};
+    const scale = (o.scale != null && o.scale > 0) ? o.scale : 1;
+    const includeWidgets = !!o.includeWidgets;
+    const outScale = (window.devicePixelRatio || 1) * scale;
+
+    // WebGPU hazard: a WebGPU canvas's drawing buffer is only valid right after
+    // its render pass.  Force a synchronous re-render of every active-GPU 2-D
+    // panel FIRST, then composite in the SAME task — so drawImage(gpuCanvas)
+    // reads freshly-rendered pixels instead of a blank/cleared buffer.
+    for (const p of panels.values()) {
+      if (p.kind === '2d' && p._gpu === 'active' && p._gpuImg
+          && p.gpuCanvas && p.gpuCanvas.style.display !== 'none') {
+        try { draw2d(p); } catch (_) {}
+      }
+    }
+
+    // The figure background element (grid) defines the ORIGIN for every
+    // relative rect.  Its top-left is the figure's top-left; the grid tracks are
+    // fixed-px and left-anchored, so panel canvases sit at the correct offset
+    // even if the grid container itself stretches wider than the figure (it can
+    // in a bare mount() page with no .apl-outer inline-block CSS constraining
+    // it).  So take the ORIGIN from the DOM but the EXTENT from the true figure
+    // size — fig_width/height (the grid content) + the 8 px gridDiv padding on
+    // each side — rather than the possibly-stretched gridDiv width.
+    const rootRect = gridDiv.getBoundingClientRect();
+    const GRID_PAD = 8;   // gridDiv padding (see the gridDiv cssText)
+    const figW = Number(model.get('fig_width'))  || 0;
+    const figH = Number(model.get('fig_height')) || 0;
+    // Fall back to the measured content box if the model lacks sizes.
+    const contentW = figW ? figW + 2 * GRID_PAD : rootRect.width;
+    const contentH = figH ? figH + 2 * GRID_PAD : rootRect.height;
+    const W = Math.max(1, Math.round(contentW * outScale));
+    const H = Math.max(1, Math.round(contentH * outScale));
+
+    const out = document.createElement('canvas');
+    out.width = W; out.height = H;
+    const octx = out.getContext('2d');
+    if (!octx) return Promise.reject(new Error('exportPNG: 2D context unavailable'));
+    octx.imageSmoothingEnabled = false;
+
+    // Figure background first (matches the on-screen gridDiv background).
+    octx.fillStyle = theme.bg;
+    octx.fillRect(0, 0, W, H);
+
+    // Draw one element scaled into the output at its position relative to root.
+    // Skips hidden (display:none) or zero-area elements; catches per-element
+    // draw failures (a tainted / uninitialised canvas) so one bad layer never
+    // aborts the whole export.
+    const _drawEl = (elm) => {
+      if (!elm) return;
+      const cs = window.getComputedStyle(elm);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return;
+      // A canvas with 0×0 backing store has nothing to blit.
+      if (elm.width === 0 || elm.height === 0) return;
+      const r = elm.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) return;
+      const dx = (r.left - rootRect.left) * outScale;
+      const dy = (r.top  - rootRect.top)  * outScale;
+      const dw = r.width  * outScale;
+      const dh = r.height * outScale;
+      try { octx.drawImage(elm, dx, dy, dw, dh); } catch (_) {}
+    };
+
+    // Per-panel canvas stack, in visual z-order (see _buildCanvasStack).
+    const _drawPanel = (p) => {
+      _drawEl(p.gpuCanvas);      // z 0 — GPU image raster (beneath)
+      _drawEl(p.plotCanvas);     // z 1 — image blit + inline decorations
+      _drawEl(p.yAxisCanvas);    // physical axis gutters (no explicit z)
+      _drawEl(p.xAxisCanvas);
+      _drawEl(p.cbCanvas);       // colorbar strip + label
+      if (includeWidgets) _drawEl(p.overlayCanvas);  // z 5 — interactive widgets
+      _drawEl(p.markersCanvas);  // z 6 — static marker groups
+      _drawEl(p.scaleBar);       // z 7 — physical scale bar
+      _drawEl(p.titleCanvas);    // z 8 — 2-D title strip
+      // (statusBar / statsDiv are hover chrome — intentionally excluded.)
+    };
+
+    // Grid panels first, then insets on top (insets sit above grid content).
+    for (const p of panels.values()) if (!p.isInset) _drawPanel(p);
+    for (const p of panels.values()) if (p.isInset)  _drawPanel(p);
+
+    let dataUrl;
+    try {
+      dataUrl = out.toDataURL('image/png');
+    } catch (e) {
+      return Promise.reject(new Error('exportPNG: toDataURL failed — ' + e));
+    }
+    return Promise.resolve({ dataUrl, width: W, height: H });
+  }
+
   // ── cell-aware CSS scaling ────────────────────────────────────────────────
   // When the notebook cell (or any container) is narrower than the figure's
   // native size, apply CSS transform:scale() to outerDiv so it shrinks
@@ -6982,6 +7088,17 @@ fn fs(in : VsOut) -> @location(0) vec4<f32> {
 
   // ── initial render ────────────────────────────────────────────────────────
   applyLayout();
+
+  // Internal API surface returned to mount().  anywidget ignores render()'s
+  // return value; mount() captures it so its handle can reach the closure's
+  // panel map + drawing helpers (exportPNG, dispose) that are otherwise
+  // inaccessible from module scope.
+  return {
+    panels,
+    exportPNG,
+    _gpuDisposeImagePanel,
+    _gpuDisposePanel,
+  };
 }
 
 export default { render };
@@ -7074,7 +7191,9 @@ export function mount(el, state, opts) {
       } catch (_) {}
     });
   }
-  render({ model, el });
+  // Capture render()'s internal API so the handle can reach the closure's
+  // panel map + drawing helpers (exportPNG / GPU dispose).
+  const api = render({ model, el }) || {};
   return {
     model,
     get(key) { return model.get(key); },
@@ -7091,13 +7210,24 @@ export function mount(el, state, opts) {
       model.set('fig_height', Math.round(height));
       model.save_changes();
     },
+    // Composite the whole figure to a PNG data URL.
+    //   opts.scale (1)               extra multiplier over devicePixelRatio
+    //   opts.includeWidgets (false)  include the interactive widget overlay
+    // Resolves to {dataUrl, width, height}; rejects with a useful message.
+    exportPNG(opts) {
+      if (typeof api.exportPNG !== 'function') {
+        return Promise.reject(new Error('exportPNG unavailable (render() returned no API)'));
+      }
+      try { return api.exportPNG(opts); }
+      catch (e) { return Promise.reject(e); }
+    },
     // Remove the figure's DOM.  (Window-level listeners registered by the
     // renderer are inert once the DOM is gone; for complete cleanup, discard
     // the containing element or iframe.)
     dispose() {
       // Free GPU resources for every panel before tearing down the DOM.
-      try { for (const p of panels.values()) {
-        _gpuDisposeImagePanel(p); _gpuDisposePanel(p);
+      try { if (api.panels) for (const p of api.panels.values()) {
+        api._gpuDisposeImagePanel(p); api._gpuDisposePanel(p);
       } } catch (_) {}
       model.off(); el.replaceChildren();
     },

--- a/anyplotlib/tests/test_embed/test_export_png.py
+++ b/anyplotlib/tests/test_embed/test_export_png.py
@@ -1,0 +1,423 @@
+"""Playwright tests for the PNG export path.
+
+Two surfaces are covered:
+
+1. ``handle.exportPNG({scale?, includeWidgets?})`` — the JS mount-handle method
+   that composites the whole figure (all panels, insets, background) onto one
+   offscreen canvas at ``devicePixelRatio × scale`` and returns
+   ``{dataUrl, width, height}``.  Exercised through the public ``mount()`` entry
+   point exactly as an Electron / SpyDE app would call it.
+
+2. The standalone-HTML ``postMessage`` export protocol — a parent page posts
+   ``{type:'anyplotlib_export_png', requestId, opts}`` into the figure iframe and
+   receives ``{type:'anyplotlib_export_png_result', requestId, dataUrl, ...}``
+   back.  This rides the same channel as the live ``state_update`` postMessages.
+
+The GPU case verifies the WebGPU readback hazard is handled: exportPNG forces a
+synchronous re-render of active-GPU panels before compositing, so
+``drawImage(gpuCanvas)`` reads live pixels instead of a blank buffer.  It is
+skipped cleanly when no WebGPU adapter is available (see ``_pw_gpu_browser``).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import pathlib
+import tempfile
+
+import numpy as np
+import pytest
+
+import anyplotlib as apl
+from anyplotlib._repr_utils import build_standalone_html
+from anyplotlib.embed import esm_path, figure_state
+from anyplotlib.tests._png_utils import decode_png
+
+# Above GPU_IMAGE_THRESHOLD (1 << 20 = 1 Mpx): the GPU image path engages in
+# auto mode for a 1200² frame (1.44 Mpx).
+GPU_IMG_N = 1200
+
+
+# ---------------------------------------------------------------------------
+# mount() page fixture (public embedding contract — no anywidget shim)
+# ---------------------------------------------------------------------------
+
+_MOUNT_PAGE = """<!DOCTYPE html>
+<html><head><meta charset="utf-8"/>
+<style>html,body{margin:0;padding:0;}</style></head>
+<body><div id="host"></div>
+<script type="module">
+const STATE = __STATE__;
+const esmSource = __ESM__;
+const blobUrl = URL.createObjectURL(new Blob([esmSource], {type: "text/javascript"}));
+import(blobUrl).then(mod => {
+  window._handle = mod.mount(document.getElementById("host"), STATE, {});
+  window._aplReady = true;
+}).catch(err => { document.body.textContent = "mount error: " + err; });
+</script></body></html>
+"""
+
+
+@pytest.fixture
+def mount_page(_pw_browser):
+    """Open a figure via the public mount() API; return the live Page."""
+    pages, paths = [], []
+
+    def _open(fig):
+        html = (_MOUNT_PAGE
+                .replace("__STATE__", json.dumps(figure_state(fig)))
+                .replace("__ESM__", json.dumps(esm_path().read_text(encoding="utf-8"))))
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", mode="w", encoding="utf-8", delete=False
+        ) as fh:
+            fh.write(html)
+            tmp = pathlib.Path(fh.name)
+        paths.append(tmp)
+        page = _pw_browser.new_page()
+        pages.append(page)
+        page.goto(tmp.as_uri())
+        page.wait_for_function("() => window._aplReady === true", timeout=15_000)
+        page.evaluate(
+            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))"
+        )
+        return page
+
+    yield _open
+    for p in pages:
+        try:
+            p.close()
+        except Exception:
+            pass
+    for f in paths:
+        f.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _export_via_handle(page, opts=None):
+    """Call window._handle.exportPNG(opts) and return {dataUrl, width, height}."""
+    return page.evaluate(
+        """(opts) => window._handle.exportPNG(opts || {})
+                .then(r => ({dataUrl: r.dataUrl, width: r.width, height: r.height}))
+                .catch(e => ({error: String(e && e.message || e)}))""",
+        opts or {},
+    )
+
+
+def _decode_data_url(data_url: str) -> np.ndarray:
+    assert data_url.startswith("data:image/png;base64,"), (
+        f"unexpected data URL prefix: {data_url[:40]!r}"
+    )
+    raw = base64.b64decode(data_url.split(",", 1)[1])
+    return decode_png(raw)
+
+
+def _is_nonblank(arr: np.ndarray) -> bool:
+    """True when the image is not a single flat colour (has real content)."""
+    rgb = arr[..., :3].reshape(-1, 3)
+    return int(np.unique(rgb, axis=0).shape[0]) > 1
+
+
+def _closest_color(arr: np.ndarray, rgb) -> int:
+    """Number of pixels whose RGB is within tol of `rgb` (per-channel <= 12)."""
+    d = np.abs(arr[..., :3].astype(np.int32) - np.asarray(rgb, dtype=np.int32))
+    return int(((d <= 12).all(axis=-1)).sum())
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic single-panel export
+# ---------------------------------------------------------------------------
+
+class TestExportBasic:
+    def test_export_nonblank_expected_size(self, mount_page):
+        fig, ax = apl.subplots(1, 1, figsize=(400, 300))
+        rng = np.random.default_rng(0)
+        ax.imshow(rng.random((32, 32)).astype(np.float32), cmap="viridis")
+        page = mount_page(fig)
+
+        res = _export_via_handle(page)
+        assert "error" not in res, res.get("error")
+        arr = _decode_data_url(res["dataUrl"])
+
+        # devicePricelRatio in headless Chromium is 1 → output == figure px.
+        # Figure background = fig_width/height + 8 px grid padding each side.
+        dpr = page.evaluate("() => window.devicePixelRatio || 1")
+        exp_w = round((400 + 16) * dpr)
+        exp_h = round((300 + 16) * dpr)
+        assert res["width"] == exp_w and res["height"] == exp_h, (
+            f"size {res['width']}x{res['height']} != expected {exp_w}x{exp_h}"
+        )
+        assert arr.shape[1] == res["width"] and arr.shape[0] == res["height"]
+        assert _is_nonblank(arr), "exported image is a single flat colour"
+
+    def test_export_known_lut_pixel(self, mount_page):
+        """A constant image at vmax must export as the colormap's high endpoint
+        colour (LUT[255]).  Proves the actual rendered pixels are captured, not
+        an empty/placeholder canvas."""
+        fig, ax = apl.subplots(1, 1, figsize=(300, 220))
+        plot = ax.imshow(np.full((32, 32), 1.0, dtype=np.float32),
+                         cmap="viridis", vmin=0.0, vmax=1.0)
+        # The high LUT endpoint the constant image maps to.
+        hi = plot.to_state_dict()["colormap_data"][255]
+
+        page = mount_page(fig)
+        res = _export_via_handle(page)
+        assert "error" not in res, res.get("error")
+        arr = _decode_data_url(res["dataUrl"])
+
+        # The fit-rect (letterboxed image) must be filled with the endpoint
+        # colour — a large fraction of the frame, and specifically the centre.
+        cy, cx = arr.shape[0] // 2, arr.shape[1] // 2
+        centre = arr[cy, cx, :3].tolist()
+        d = max(abs(centre[i] - hi[i]) for i in range(3))
+        assert d <= 12, (
+            f"centre pixel {centre} != expected viridis endpoint {hi} (dmax={d})"
+        )
+        # And the colour must cover a large area (the whole image region).
+        assert _closest_color(arr, hi) > 0.2 * arr.shape[0] * arr.shape[1], (
+            "endpoint colour does not fill the image area"
+        )
+
+    def test_export_scale_multiplies_size(self, mount_page):
+        fig, ax = apl.subplots(1, 1, figsize=(200, 160))
+        ax.imshow(np.random.default_rng(1).random((16, 16)).astype(np.float32))
+        page = mount_page(fig)
+
+        base = _export_via_handle(page, {"scale": 1})
+        big = _export_via_handle(page, {"scale": 2})
+        assert "error" not in base and "error" not in big
+        assert big["width"] == base["width"] * 2
+        assert big["height"] == base["height"] * 2
+
+    def test_widgets_excluded_by_default(self, mount_page):
+        """A drawn rectangle widget must NOT appear unless includeWidgets=True.
+
+        The widget's red/accent stroke lives on the overlayCanvas (z-index 5),
+        which the default composite skips.
+        """
+        fig, ax = apl.subplots(1, 1, figsize=(360, 300))
+        plot = ax.imshow(np.zeros((32, 32), dtype=np.float32),
+                         cmap="gray", vmin=0.0, vmax=1.0)
+        plot.add_widget("rectangle", x=6.0, y=6.0, w=18.0, h=18.0)
+        page = mount_page(fig)
+        # let the overlay draw the widget
+        page.evaluate(
+            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))"
+        )
+
+        without = _decode_data_url(_export_via_handle(page, {})["dataUrl"])
+        withw = _decode_data_url(
+            _export_via_handle(page, {"includeWidgets": True})["dataUrl"])
+
+        # The two exports must be the SAME size, and differ (widget adds ink).
+        assert without.shape == withw.shape
+        diff = np.abs(without.astype(np.int32) - withw.astype(np.int32)).sum()
+        assert diff > 0, (
+            "includeWidgets=True produced an identical image — overlay not drawn"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-panel export
+# ---------------------------------------------------------------------------
+
+class TestExportMultiPanel:
+    def test_two_panels_both_present(self, mount_page):
+        """subplots(1, 2) with two distinct constant-colour images must export
+        both panels, each in its own half of the composite."""
+        fig, axes = apl.subplots(1, 2, figsize=(240, 200))
+        # Left panel: low endpoint; right panel: high endpoint. Different cmaps
+        # so the two halves are unmistakably distinct colours.
+        pl = axes[0].imshow(np.full((24, 24), 0.0, dtype=np.float32),
+                            cmap="viridis", vmin=0.0, vmax=1.0)
+        pr = axes[1].imshow(np.full((24, 24), 1.0, dtype=np.float32),
+                            cmap="magma", vmin=0.0, vmax=1.0)
+        left_lo = pl.to_state_dict()["colormap_data"][0]     # viridis dark blue
+        right_hi = pr.to_state_dict()["colormap_data"][255]  # magma pale yellow
+
+        page = mount_page(fig)
+        res = _export_via_handle(page)
+        assert "error" not in res, res.get("error")
+        arr = _decode_data_url(res["dataUrl"])
+
+        H, Wtot = arr.shape[0], arr.shape[1]
+        left_half = arr[:, : Wtot // 2, :3]
+        right_half = arr[:, Wtot // 2:, :3]
+
+        # Left panel colour lives in the LEFT half, right panel colour in the
+        # RIGHT half — proves both panels rendered AND are positioned correctly.
+        assert _closest_color(left_half, left_lo) > 0.05 * left_half.shape[0] * left_half.shape[1], (
+            "left panel colour missing from left half"
+        )
+        assert _closest_color(right_half, right_hi) > 0.05 * right_half.shape[0] * right_half.shape[1], (
+            "right panel colour missing from right half"
+        )
+        # And they must NOT be swapped (right colour should be rare on the left).
+        assert _closest_color(left_half, right_hi) < _closest_color(right_half, right_hi)
+
+
+# ---------------------------------------------------------------------------
+# 3. Iframe postMessage round-trip (standalone HTML template)
+# ---------------------------------------------------------------------------
+
+_PARENT_PAGE = """<!DOCTYPE html>
+<html><head><meta charset="utf-8"/><style>html,body{margin:0;padding:0;}</style></head>
+<body>
+<iframe id="fig" srcdoc="__SRCDOC__" width="360" height="280"
+        style="border:none;"></iframe>
+<script>
+window._exportResult = null;
+window.addEventListener('message', (e) => {
+  if (e.data && e.data.type === 'anyplotlib_export_png_result') {
+    window._exportResult = e.data;
+  }
+});
+window._requestExport = function(opts) {
+  window._exportResult = null;
+  const ifr = document.getElementById('fig');
+  ifr.contentWindow.postMessage(
+    {type: 'anyplotlib_export_png', requestId: 'rq1', opts: opts || {}}, '*');
+};
+</script>
+</body></html>
+"""
+
+
+class TestExportIframeRoundTrip:
+    def test_postmessage_export_returns_png(self, _pw_browser):
+        fig, ax = apl.subplots(1, 1, figsize=(320, 240))
+        ax.imshow(np.random.default_rng(2).random((32, 32)).astype(np.float32),
+                  cmap="viridis")
+
+        srcdoc = build_standalone_html(fig, resizable=False)
+        # Escape for the srcdoc attribute (mirrors repr_html_iframe / SpyDE).
+        from html import escape
+        parent = _PARENT_PAGE.replace("__SRCDOC__", escape(srcdoc, quote=True))
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", mode="w", encoding="utf-8", delete=False
+        ) as fh:
+            fh.write(parent)
+            tmp = pathlib.Path(fh.name)
+
+        page = _pw_browser.new_page()
+        try:
+            page.goto(tmp.as_uri())
+            # Wait until the figure inside the iframe has rendered (the export
+            # API is set on the render() return).  Give the module import +
+            # first paint a couple of frames.
+            page.wait_for_timeout(500)
+            page.evaluate("() => window._requestExport({})")
+            page.wait_for_function(
+                "() => window._exportResult !== null", timeout=15_000)
+            result = page.evaluate("() => window._exportResult")
+        finally:
+            page.close()
+            tmp.unlink(missing_ok=True)
+
+        assert result.get("requestId") == "rq1"
+        assert not result.get("error"), f"export error: {result.get('error')}"
+        assert result.get("dataUrl", "").startswith("data:image/png;base64,")
+        arr = _decode_data_url(result["dataUrl"])
+        assert result["width"] > 0 and result["height"] > 0
+        assert arr.shape[1] == result["width"] and arr.shape[0] == result["height"]
+        assert _is_nonblank(arr), "iframe-exported PNG is a single flat colour"
+
+
+# ---------------------------------------------------------------------------
+# 4. GPU (WebGPU readback) export
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def gpu_mount_page(_pw_gpu_browser):
+    """Open a figure via mount() in the WebGPU-capable browser.
+
+    Returns ``open(fig, expect_gpu=False) -> page``.  With ``expect_gpu=True``
+    it waits until every 2-D image panel reports the GPU path active (the async
+    device init + activation redraw landed), so a subsequent exportPNG is
+    guaranteed to composite the WebGPU rendering, not a first-frame Canvas2D
+    fallback.  Skipped when no adapter is available (via ``_pw_gpu_browser``).
+    """
+    pages, paths = [], []
+
+    def _open(fig, expect_gpu=False):
+        html = (_MOUNT_PAGE
+                .replace("__STATE__", json.dumps(figure_state(fig)))
+                .replace("__ESM__", json.dumps(esm_path().read_text(encoding="utf-8"))))
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", mode="w", encoding="utf-8", delete=False
+        ) as fh:
+            fh.write(html)
+            tmp = pathlib.Path(fh.name)
+        paths.append(tmp)
+        page = _pw_gpu_browser.new_page()
+        pages.append(page)
+        page.goto(tmp.as_uri())
+        page.wait_for_function("() => window._aplReady === true", timeout=15_000)
+        page.evaluate(
+            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))"
+        )
+        if expect_gpu:
+            page.wait_for_function(
+                """() => {
+                    const d = globalThis.__apl_gpu2d || {};
+                    const v = Object.values(d);
+                    return v.length > 0 && v.every(x => x.active);
+                }""",
+                timeout=20_000,
+            )
+        return page
+
+    yield _open
+    for p in pages:
+        try:
+            p.close()
+        except Exception:
+            pass
+    for f in paths:
+        f.unlink(missing_ok=True)
+
+
+def _gpu_asym_image(n=GPU_IMG_N):
+    """Gradient + distinct corner blocks: content the composite must capture."""
+    yy, xx = np.mgrid[0:n, 0:n].astype(np.float32)
+    img = (xx / n) * 0.3 + (yy / n) * 0.3
+    img[(yy < n // 3) & (xx < n // 3)] = 1.0
+    img[(yy > 2 * n // 3) & (xx > 2 * n // 3)] = 0.8
+    return img
+
+
+class TestExportGpu:
+    def test_gpu_export_nonblank(self, gpu_mount_page):
+        """A large scalar image engaging the WebGPU path must export non-blank.
+
+        This is the readback test: exportPNG forces a synchronous re-render of
+        the active-GPU panel before drawImage(gpuCanvas), so the GPU raster is
+        captured instead of a blank drawing buffer.
+        """
+        fig, ax = apl.subplots(1, 1, figsize=(400, 300))
+        plot = ax.imshow(_gpu_asym_image(), cmap="viridis",
+                         vmin=0.0, vmax=1.0, gpu=True)
+        hi = plot.to_state_dict()["colormap_data"][255]  # value-1.0 endpoint
+
+        page = gpu_mount_page(fig, expect_gpu=True)
+
+        # Confirm the GPU path is actually the one painting this frame.
+        diag = page.evaluate("() => globalThis.__apl_gpu2d || {}")
+        assert diag and all(d.get("active") for d in diag.values()), (
+            f"GPU path not active: {diag}"
+        )
+
+        res = _export_via_handle(page)
+        assert "error" not in res, res.get("error")
+        arr = _decode_data_url(res["dataUrl"])
+        assert _is_nonblank(arr), (
+            "GPU export is a single flat colour — WebGPU readback returned blank"
+        )
+        # The bright top-left block (value 1.0) → viridis endpoint colour must
+        # be present, proving the GPU raster (not just decorations) was drawn.
+        assert _closest_color(arr, hi) > 500, (
+            "GPU-rendered image content missing from export (blank gpuCanvas?)"
+        )


### PR DESCRIPTION
## Summary
- `handle.exportPNG({scale, includeWidgets})` composites the per-panel canvas stack (gpu/plot/axes/colorbar/markers/scalebar/title, insets on top) onto one offscreen canvas at DPR×scale and resolves to a PNG data URL.
- WebGPU panels are force-redrawn and read back in the same synchronous task — callers need no settling delay.
- Standalone HTML gains a `message` listener (`anyplotlib_export_png` → `anyplotlib_export_png_result`) so iframe hosts (SpyDE report cells) can harvest WYSIWYG snapshots.
- Side fix: `render()` now returns its internal api and `mount()` captures it — `mount().dispose()` previously referenced closure state it couldn't reach and silently no-oped.

Branch is based on `release/v0.2.0` (main hasn't caught up to the release-prep commits), so those two commits appear in the diff until main is fast-forwarded.

## Tests
`tests/test_embed/test_export_png.py`: 7 passed (basic pixel/LUT checks, multi-panel arrangement, iframe postMessage round-trip, WebGPU readback — skips cleanly without an adapter). Full `test_embed/` + `test_plot2d/` + `test_layouts/` regression: 439 passed, 6 pre-existing baseline skips.