### PR TITLE
fix(ci): serialise docs deploys so release tags stop racing main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,13 @@ on:
   # Allow manual re-builds from the Actions tab.
   workflow_dispatch:
 
-# Only one docs deployment should run at a time to avoid race conditions on
-# the gh-pages branch.
+# Per-ref grouping so a new push supersedes an in-flight BUILD of the same
+# ref (PR iterations, repeated pushes to main). This deliberately does NOT
+# serialise deployments: a push to main and its release tag are different
+# refs, so they land in different groups. The deploy job carries its own
+# ref-independent group for that — see below.
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-build-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -90,6 +93,17 @@ jobs:
     runs-on: ubuntu-latest
     # Skip deployment for pull requests.
     if: github.event_name != 'pull_request'
+
+    # Every deploy pushes to the SAME branch (gh-pages), so they must be
+    # serialised across refs, not per-ref. Releasing tags main and v* almost
+    # simultaneously, which previously raced: whichever run pushed second was
+    # rejected with "cannot lock ref 'refs/heads/gh-pages'" and its version
+    # directory never appeared, while switcher.json still advertised it.
+    # cancel-in-progress is false because these runs must QUEUE — cancelling
+    # one would drop a version directory just as surely as the race did.
+    concurrency:
+      group: docs-deploy
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository

--- a/upcoming_changes/+docs-deploy-race.bugfix.rst
+++ b/upcoming_changes/+docs-deploy-race.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed the docs deployment racing itself on release. A push to ``main`` and its
+release tag are different refs, so the ``docs-${{ github.ref }}`` concurrency
+group put them in separate groups and both pushed to ``gh-pages`` at once; the
+loser was rejected and its versioned directory never appeared, while
+``switcher.json`` still advertised the version. The deploy job now uses a
+ref-independent group so deployments queue instead.

--- a/upcoming_changes/.gitkeep
+++ b/upcoming_changes/.gitkeep
@@ -1,0 +1,3 @@
+# This file keeps the upcoming_changes/ directory tracked by git.
+# Replace it with real fragment files (e.g. 42.new_feature.rst) as PRs land.
+


### PR DESCRIPTION
## The failure

The `Docs` run for tag `v0.5.0` failed at the deploy step:

```
! [remote rejected] gh-pages -> gh-pages
  (cannot lock ref 'refs/heads/gh-pages': is at 38726cd but expected 0f190b2)
```

`Build docs` succeeded — only the push lost.

## Why the existing guard didn't catch it

```yaml
# Only one docs deployment should run at a time to avoid race conditions on
# the gh-pages branch.
concurrency:
  group: docs-${{ github.ref }}
```

A push to `main` and a push to its `v*` tag are **different refs**, so they go
into **different** concurrency groups and run concurrently. Both push to
`gh-pages`; the second is rejected. The guard never applied to the case its own
comment describes.

## Why it matters more than a red X

`prepare_release` adds the new version to `switcher.json` regardless, so a lost
deploy leaves the switcher advertising a directory that doesn't exist. On
`gh-pages` today **both `v0.4.2` and `v0.5.0` are missing** while the switcher
offers them — those entries 404.

## The fix

Split the two concerns:

- workflow level keeps a **per-ref** group (`docs-build-${{ github.ref }}`) so a
  new push still supersedes an in-flight build of the same ref — PR iterations
  keep cancelling as before.
- the `deploy` job takes a **ref-independent** group (`docs-deploy`) with
  `cancel-in-progress: false`, so deploys **queue**. Cancelling would drop a
  version directory just as surely as the race did.

## Backfill

Not included here. Re-running the two Docs runs publishes the missing
directories — `keep_files: true` makes deploys additive, so nothing is
overwritten. I've already re-run the `v0.5.0` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TTbBeDrPJBTpruuszC3mD