### PR TITLE
fix(docs): document KeyOverlay id/name once, on the properties

### DIFF
--- a/anyplotlib/keys.py
+++ b/anyplotlib/keys.py
@@ -37,14 +37,6 @@ class KeyOverlay:
         key = plot.add_key(ipf_triangle, corner="bottom-right")
         key.set(size=0.3, bgcolor="none")
         key.visible = False          # plain attribute assignment also pushes
-
-    Attributes
-    ----------
-    id : str
-        Short unique identifier.
-    name : str
-        Caller-supplied name, or the id when none was given.  Use it with
-        :meth:`~anyplotlib.Plot2D.get_key`.
     """
 
     #: Fields that live on the light view channel.  The image itself does NOT
@@ -68,10 +60,15 @@ class KeyOverlay:
 
     @property
     def id(self) -> str:
+        """Short unique identifier."""
         return self._id
 
     @property
     def name(self) -> str:
+        """Caller-supplied name, or the id when none was given.
+
+        Use it with :meth:`~anyplotlib.Plot2D.get_key`.
+        """
         return self._name
 
     # ── attribute access ──────────────────────────────────────────────

--- a/upcoming_changes/53.doc.rst
+++ b/upcoming_changes/53.doc.rst
@@ -1,0 +1,4 @@
+Fixed the documentation build failing on
+:class:`~anyplotlib.keys.KeyOverlay`, whose ``id`` and ``name`` were described
+both in the class docstring and by the properties themselves — a duplicate
+object description, which the build treats as an error.


### PR DESCRIPTION
## The bug

The **docs build has been red on every commit since the keys work landed in v0.7.0** — `322029eb` was the last green run. It is not specific to any PR; `main` itself fails at `78b6819e`.

`KeyOverlay.id` and `.name` are documented twice: once in the class docstring's `Attributes` block, and again as bare `@property` definitions that `autoclass :members:` in `docs/api/keys.rst` picks up. Sphinx reports each as a duplicate object description, and `docs.yml` builds with `-W`:

```
<unknown>:1: WARNING: duplicate object description of anyplotlib.keys.KeyOverlay.id, other instance in api/keys, use :no-index: for one of them
<unknown>:1: WARNING: duplicate object description of anyplotlib.keys.KeyOverlay.name, other instance in api/keys, use :no-index: for one of them
build finished with problems, 2 warnings (with warnings treated as errors)
```

Because `Deploy docs` is gated on `needs: build`, the published docs have not updated since v0.7.0 either.

## The fix

Move the two descriptions onto the properties and drop the `Attributes` block.

The warning message itself suggests `:no-index:`, but that just suppresses one of two copies that would still have to be kept in sync by hand. The properties had no docstrings at all, so putting the text there is where it belonged: one copy, at the definition, and the rendered page is unchanged — both descriptions still appear under `id` and `name` in the API reference (verified in the built HTML).

## Verification

- Full `sphinx-build -b html docs build/html -W --keep-going` (the exact CI invocation, with the Pyodide wheel staged first): **build succeeded, zero warnings**, versus 2 before the change on the same tree.
- `test_keys` + `test_documentation`: 68 passed.

Independent of #52; either can merge first.